### PR TITLE
Two improvements for user-session@.service

### DIFF
--- a/units/system/user-session@.service.in
+++ b/units/system/user-session@.service.in
@@ -12,7 +12,7 @@ After=systemd-user-sessions.service
 [Service]
 User=%I
 PAMName=login
-ControlGroup=%R/user/%I/shared cpu:/
+ControlGroup=%R/user/%I/shared cpu:/ memory:/
 ControlGroupModify=yes
 Type=notify
 TTYPath=/dev/tty1


### PR DESCRIPTION
This is a 2-commit patch series:

The first commit fixes logind session "activation", so that the user session will be assigned a type of "tty" and the seat "seat0".  A nice side effect is that polkit will succeed in identifying active sessions, so that non-root user can carry out actions like suspend, reboot, and poweroff when appropriate.

The second commit enables setting MemoryLimit and MemorySoftLimit for user session services, previously only possible with system services.
