### PR TITLE
Honor /etc/profile(.d) in user-session.service

### DIFF
--- a/units/system/user-session@.service.in
+++ b/units/system/user-session@.service.in
@@ -16,7 +16,7 @@ ControlGroup=%R/user/%I/shared cpu:/ memory:/
 ControlGroupModify=yes
 Type=notify
 TTYPath=/dev/tty1
-ExecStart=-@SYSTEMDUTILDIR@/systemd --user
+ExecStart=-/bin/sh -l -c "exec @SYSTEMDUTILDIR@/systemd --user"
 Environment=DISPLAY=:0
 Environment=XDG_RUNTIME_DIR=/run/user/%I
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%I/dbus/user_bus_socket


### PR DESCRIPTION
Distros often set some environment variables from /etc/profile, and have
packages with drop-in files for /etc/profile.d/ to set bits of $PATH and
so on. Many users have additional envvars in ~/.profile of their own.
These should be parsed, at least for now.
