### PR TITLE
launcher: set groups/GID before setting the UID

### DIFF
--- a/src/launcher.c
+++ b/src/launcher.c
@@ -13,6 +13,7 @@
 
 #include <errno.h>
 #include <getopt.h>
+#include <grp.h>
 #include <poll.h>
 #include <pwd.h>
 #include <signal.h>
@@ -174,6 +175,14 @@ int main(int argc, char **argv)
 		}
 		free(*s);
 	}
+
+	/* Be sure to not inherit root's supplemental groups */
+	if (initgroups(pw->pw_name, pw->pw_gid) != 0)
+		perror("initgroups");
+
+	/* Change our gid while we're still privileged */
+	if (setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) != 0)
+		perror("setresgid");
 
 	/* We don't need to be privileged when the session closes */
 	if (setresuid(pw->pw_uid, pw->pw_uid, pw->pw_uid) != 0)


### PR DESCRIPTION
This is an additional change to fix up groups for the process before we drop privilege.

From the commit message:

---

If setresuid(2) is called on its own, the process will still have group
"root", but it should be the group for the user with UID.

Also, setresgid(2) sets the supplementary groups for the process from
the "current set", which is root's set in this case, so change the
current set with initgroups(3) to use UID's supplementary groups.
