### PR TITLE
Use ldflags from systemd's pkgconfig

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ user_session_launch_SOURCES = \
 
 # FIXME: add pkgconfig checks for these instead
 user_session_launch_LDADD = \
-	-lsystemd-login \
+	$(SYSTEMD_LIBS) \
 	-lpam \
 	-lpam_misc
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ user_session_launch_SOURCES = \
 
 # FIXME: add pkgconfig checks for these instead
 user_session_launch_LDADD = \
-	$(SYSTEMD_LIBS) \
+	$(LIBSYSTEMD_LIBS) \
 	-lpam \
 	-lpam_misc
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,8 @@ AC_SUBST(SYSTEMDUSERUNITDIR)
 SYSTEMDUTILDIR="`$PKG_CONFIG --variable=systemdutildir systemd`"
 AC_SUBST(SYSTEMDUTILDIR)
 
+PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd >= 209])
+
 # test for xorg-launch-helper
 AC_MSG_CHECKING(for xorg-launch-helper)
 if test -f "$SYSTEMDUSERUNITDIR/xorg.target" ; then


### PR DESCRIPTION
Removing the hardcoded -lsystemd-login also fixes builds against systemd >= 209 (issue #18)